### PR TITLE
Add github workflows

### DIFF
--- a/.github/workflows/deploy-production-subgraph.yaml
+++ b/.github/workflows/deploy-production-subgraph.yaml
@@ -1,0 +1,37 @@
+name: Production Subgraph (Mainnet)
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      # Install commands
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+          registry-url: https://registry.npmjs.org
+      - name: yarn add @graphprotocol/graph-cli
+        run: yarn add @graphprotocol/graph-cli
+      - name: yarn add ts-node
+        run: yarn add ts-node
+      - name: yarn install
+        run: yarn install
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.graphprotocol_npm_token}}
+
+      # Run scripts
+      - name: Prepare addresses mainnet
+        run: ./node_modules/.bin/ts-node config/mainnetAddressScript.ts && ./node_modules/.bin/mustache ./config/generatedAddresses.json ./config/addresses.template.ts > ./config/addresses.ts
+      - name: Prepare mainnet
+        run: ./node_modules/.bin/mustache ./config/generatedAddresses.json subgraph.template.yaml > subgraph.yaml && ./node_modules/@graphprotocol/graph-cli/bin/graph codegen --output-dir src/types/
+      - name: Deploy to mainnet production
+        run: ./node_modules/@graphprotocol/graph-cli/bin/graph deploy graphprotocol/graph-network-analytics --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/ --access-token ${{secrets.access_token}}

--- a/.github/workflows/deploy-staging-subgraph.yaml
+++ b/.github/workflows/deploy-staging-subgraph.yaml
@@ -1,0 +1,37 @@
+name: Staging Subgraph (Mainnet)
+
+on:
+  push:
+    branches:
+      - mainnet-staging
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      # Install commands
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+          registry-url: https://registry.npmjs.org
+      - name: yarn add @graphprotocol/graph-cli
+        run: yarn add @graphprotocol/graph-cli
+      - name: yarn add ts-node
+        run: yarn add ts-node
+      - name: yarn install
+        run: yarn install
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.graphprotocol_npm_token}}
+
+      # Run scripts
+      - name: Prepare addresses mainnet
+        run: ./node_modules/.bin/ts-node config/mainnetAddressScript.ts && ./node_modules/.bin/mustache ./config/generatedAddresses.json ./config/addresses.template.ts > ./config/addresses.ts
+      - name: Prepare mainnet
+        run: ./node_modules/.bin/mustache ./config/generatedAddresses.json subgraph.template.yaml > subgraph.yaml && ./node_modules/@graphprotocol/graph-cli/bin/graph codegen --output-dir src/types/
+      - name: Deploy to mainnet staging
+        run: ./node_modules/@graphprotocol/graph-cli/bin/graph deploy graphprotocol/graph-network-analytics-staging --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/ --access-token ${{secrets.access_token}}

--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ Note that you will have to fill in your own subgraph name in the npm script, whe
 `<INSERT_SUBGRAPH_NAME>`. Depending if you are deploying to rinkeby or mainnet, you will also
 have to fill in `prepare:rinkeby` or `prepare:mainnet` where it has `<INSERT_MAINNET_OR_RINKEBY>`.
 
+## Automated deploy
+**Staging**
+- When `mainnet-staging` branch is updated, it will automatically deploy the subgraph to hosted service under the name `graphprotocol/graph-network-analytics-staging`
+
 ## Documentation
 
 For documentation on the subgraph, please see [DOCUMENTATION.md](./DOCUMENTATION.md).


### PR DESCRIPTION
I see that we have "hooks" for deploy to production (once stuff get's merged to master), but not sure if they are working in this repo.
My setup for prod is that you need to tag it and then it will run production deploy, for example:
```
git tag -m "Update subgraph" v1.0.1
git push --tags
```

We can use either setup, it's good to have both