### PR TITLE
Fixed issue with creation of delegator data point

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -1052,6 +1052,9 @@ type DelegatorDailyData @entity {
   "[CURRENT] Aggregation of realized rewards across all stakes"
   totalRealizedRewards: BigDecimal!
 
+  "[CURRENT] Current delegation for the delegator across all stakes"
+  currentDelegation: BigDecimal!
+
   "[CURRENT] Amount of DelegatedStake entities this entity tracks"
   stakesCount: BigInt!
 }

--- a/src/mappings/helpers.ts
+++ b/src/mappings/helpers.ts
@@ -322,20 +322,6 @@ export function createOrLoadPool(id: BigInt): Pool {
   return pool as Pool
 }
 
-export function createEpoch(startBlock: i32, epochLength: i32, epochNumber: i32): Epoch {
-  let epoch = new Epoch(BigInt.fromI32(epochNumber).toString())
-  epoch.startBlock = startBlock
-  epoch.endBlock = startBlock + epochLength
-  epoch.signalledTokens = BigInt.fromI32(0)
-  epoch.stakeDeposited = BigInt.fromI32(0)
-  epoch.queryFeeRebates = BigInt.fromI32(0)
-  epoch.totalRewards = BigInt.fromI32(0)
-  epoch.totalIndexerRewards = BigInt.fromI32(0)
-  epoch.totalDelegatorRewards = BigInt.fromI32(0)
-  epoch.save()
-  return epoch
-}
-
 export function createOrLoadGraphNetwork(): GraphNetwork {
   let graphNetwork = GraphNetwork.load('1')
   if (graphNetwork == null) {
@@ -601,7 +587,9 @@ export function compoundId(idA: string, idB: string): string {
   return idA.concat('-').concat(idB)
 }
 
-export function batchUpdateDelegatorsForIndexer(indexer: Indexer, timestamp: BigInt): void {
+export function batchUpdateDelegatorsForIndexer(indexerId: string, timestamp: BigInt): void {
+  // Loading it again here to make sure we have the latest up to date data on the entity.
+  let indexer = Indexer.load(indexerId)
   // pre-calculates a lot of data for all delegators that exists for a specific indexer
   // using already existing links with the indexer-delegatedStake relations
   for (let i = 0; i < indexer.delegatorsCount.toI32(); i++) {
@@ -728,6 +716,7 @@ export function getAndUpdateDelegatorDailyData(
 
   dailyData.stakesCount = entity.stakesCount
   dailyData.stakedTokens = entity.stakedTokens
+  dailyData.currentDelegation = entity.currentDelegation
   dailyData.lockedTokens = entity.lockedTokens
   dailyData.totalUnrealizedRewards = entity.totalUnrealizedRewards
   dailyData.totalRealizedRewards = entity.totalRealizedRewards

--- a/src/mappings/rewardsManager.ts
+++ b/src/mappings/rewardsManager.ts
@@ -81,7 +81,7 @@ export function handleRewardsAssigned(event: RewardsAssigned): void {
   )
   graphNetwork.save()
 
-  batchUpdateDelegatorsForIndexer(indexer as Indexer, event.block.timestamp)
+  batchUpdateDelegatorsForIndexer(indexer.id, event.block.timestamp)
 
   getAndUpdateIndexerDailyData(indexer as Indexer, event.block.timestamp)
   getAndUpdateSubgraphDeploymentDailyData(

--- a/src/mappings/staking.ts
+++ b/src/mappings/staking.ts
@@ -261,7 +261,7 @@ export function handleStakeDelegated(event: StakeDelegated): void {
   graphNetwork.totalDelegatedTokens = graphNetwork.totalDelegatedTokens.plus(event.params.tokens)
   graphNetwork.save()
 
-  batchUpdateDelegatorsForIndexer(indexer as Indexer, event.block.timestamp)
+  batchUpdateDelegatorsForIndexer(indexer.id, event.block.timestamp)
 
   // analytics
   let indexerDailyData = getAndUpdateIndexerDailyData(indexer as Indexer, event.block.timestamp)
@@ -330,7 +330,7 @@ export function handleStakeDelegatedLocked(event: StakeDelegatedLocked): void {
   graphNetwork.save()
 
   // batch update delegs
-  batchUpdateDelegatorsForIndexer(indexer as Indexer, event.block.timestamp)
+  batchUpdateDelegatorsForIndexer(indexer.id, event.block.timestamp)
 
   // analytics
   let indexerDailyData = getAndUpdateIndexerDailyData(indexer as Indexer, event.block.timestamp)
@@ -363,7 +363,7 @@ export function handleStakeDelegatedWithdrawn(event: StakeDelegatedWithdrawn): v
   delegatedStake.lockedUntil = 0
   delegatedStake.save()
 
-  batchUpdateDelegatorsForIndexer(indexer as Indexer, event.block.timestamp)
+  batchUpdateDelegatorsForIndexer(indexer.id, event.block.timestamp)
 
   // analytics
   let indexerDailyData = getAndUpdateIndexerDailyData(indexer as Indexer, event.block.timestamp)
@@ -618,7 +618,7 @@ export function handleRebateClaimed(event: RebateClaimed): void {
   )
   graphNetwork.save()
 
-  batchUpdateDelegatorsForIndexer(indexer as Indexer, event.block.timestamp)
+  batchUpdateDelegatorsForIndexer(indexer.id, event.block.timestamp)
 
   getAndUpdateIndexerDailyData(indexer as Indexer, event.block.timestamp)
   getAndUpdateSubgraphDeploymentDailyData(


### PR DESCRIPTION
* Fixed issue with the creation of new delegator daily data for a new delegation. The indexer data used was missing a small updated to the amount of delegators it had, because the update was done on a different context and saved, while the indexer data used was from a hot loaded entity that wasn't being updated. Fix consisted on re-loading the entity when it needed to be used.
* Added `currentDelegation` to the `DelegatorDailyData` entity, which was implemented in the base entity but missing from the daily data entity.
* Removed unused epoch creation code.