### PR TITLE
GNS null check for createGraphAccountName

### DIFF
--- a/src/mappings/helpers.ts
+++ b/src/mappings/helpers.ts
@@ -483,10 +483,13 @@ function createGraphAccountName(
     // check that this name is not already used by another graph account (changing ownership)
     // If so, remove the old owner, and set the new one
   } else if (graphAccountName.graphAccount != graphAccount) {
-    // Set defaultDisplayName to null if they lost ownership of this name
-    let oldGraphAccount = GraphAccount.load(graphAccountName.graphAccount)
-    oldGraphAccount.defaultDisplayName = null
-    oldGraphAccount.save()
+    // Only update the old graph account if it exists
+    if (graphAccountName.graphAccount != null) {
+      // Set defaultDisplayName to null if they lost ownership of this name
+      let oldGraphAccount = GraphAccount.load(graphAccountName.graphAccount)
+      oldGraphAccount.defaultDisplayName = null
+      oldGraphAccount.save()
+    }
 
     graphAccountName.graphAccount = graphAccount
     graphAccountName.save()

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -1,6 +1,11 @@
-specVersion: 0.0.2
+specVersion: 0.0.4
 description: Graph Network analytics subgraph
 repository: https://github.com/graphprotocol/graph-network-analytics-subgraph
+features:
+  - grafting
+graft:
+  base: QmQSrYeZdakpvHKUB8FFgjJipUiee25JSK3gXKYyjVEu7k
+  block: 13887937
 schema:
   file: ./schema.graphql
 dataSources:


### PR DESCRIPTION
This subgraph stopped indexing at block 13887938
![Screen Shot 2021-12-27 at 10 20 20 AM](https://user-images.githubusercontent.com/16529164/147507042-67598a55-ed85-4fd7-85f3-bebce68f22a3.png)
[This fix](https://github.com/graphprotocol/graph-network-subgraph/commit/2f2e6e9c08318d136a5c90c7cb806c3649f44bac) was introduced by Juan today on Dec 27 and needs to be added to the analytics subgraph as well

The version is bumped to 0.04 since having the [Grafting feature](https://thegraph.com/docs/en/developer/create-subgraph-hosted/#grafting-onto-existing-subgraphs) needs this version at least.

The original Deployment ID of 
the previous Graph Network Analytics Subgraph was `QmQSrYeZdakpvHKUB8FFgjJipUiee25JSK3gXKYyjVEu7k`
