### PR TITLE
Sync staging changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,9 +38,9 @@
     "prettier-write": "prettier --write '**/*.ts'"
   },
   "devDependencies": {
-    "@graphprotocol/contracts": "5.3.3",
-    "@graphprotocol/graph-cli": "^0.51.0",
-    "@graphprotocol/graph-ts": "^0.31.0",
+    "@graphprotocol/contracts": "6.2.0",
+    "@graphprotocol/graph-cli": "0.68.0",
+    "@graphprotocol/graph-ts": "0.32.0",
     "@types/node": "^14.0.13",
     "@typescript-eslint/eslint-plugin": "^3.3.0",
     "@typescript-eslint/parser": "^3.3.0",

--- a/src/mappings/ethereumDIDRegistry.ts
+++ b/src/mappings/ethereumDIDRegistry.ts
@@ -17,7 +17,8 @@ export function handleDIDAttributeChanged(event: DIDAttributeChanged): void {
     // called it directly, it could crash the subgraph
     let hexHash = changetype<Bytes>(addQm(event.params.value))
     let base58Hash = hexHash.toBase58()
-    let metadataId = graphAccount.id.concat('-').concat(base58Hash)
+    let uniqueTxID = event.transaction.hash.toHexString().concat('-').concat(event.logIndex.toString())
+    let metadataId = uniqueTxID.concat('-').concat(graphAccount.id.concat('-').concat(base58Hash))
     graphAccount.metadata = metadataId
     graphAccount.save()
 

--- a/src/mappings/rewardsManager.ts
+++ b/src/mappings/rewardsManager.ts
@@ -80,6 +80,7 @@ export function handleRewardsAssigned(event: RewardsAssigned): void {
   graphNetwork.totalIndexingDelegatorRewards = graphNetwork.totalIndexingDelegatorRewards.plus(
     delegatorIndexingRewards,
   )
+  graphNetwork.totalDelegatedTokens = graphNetwork.totalDelegatedTokens.plus(delegatorIndexingRewards)
   graphNetwork.save()
 
   batchUpdateDelegatorsForIndexer(indexer.id, event.block.timestamp)

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -1,8 +1,15 @@
-specVersion: 0.0.2
+specVersion: 1.0.0
 description: Graph Network analytics subgraph
 repository: https://github.com/graphprotocol/graph-network-analytics-subgraph
 features:
   - fullTextSearch
+indexerHints:
+{{#isL1}}
+  prune: 400
+{{/isL1}}
+{{^isL1}}
+  prune: 15000
+{{/isL1}}
 schema:
   file: ./schema.graphql
 dataSources:


### PR DESCRIPTION
Fixes:
* Fixed `GraphNetwork.totalDelegatedTokens`
* Fixed `GraphNetwork.totalUnstakedTokensLocked`
* Fixed `GraphAccountMetadata` not being the same as in core network subgraph

Manifest changes:
* Added auto pruning. This disables time travel queries.
* Auto pruning settings:
  * 400 blocks for L1 (roughly over 1 hour on ethereum mainnet)
  * 15000 blocks for L2 (roughly over 1 hour on arbitrum one)
* Bumped spec version to 1.0.0 to enable auto pruning

Dependencies changes:
* Bumped contracts package from 5.3.3 to 6.2.0
* Bumped graph-cli package from 0.48.0 to 0.68.0
* Bumped graph-ts package from 0.29.3 to 0.32.0

Breaking changes:
* Auto pruning removes support for time travel queries older than the specified blocks for L1 (400) and L2 (15000). This breaks any app relying on historical data from this subgraph.